### PR TITLE
derive connection details from pgpass file

### DIFF
--- a/server/environment.d.ts
+++ b/server/environment.d.ts
@@ -1,0 +1,19 @@
+declare global {
+  namespace NodeJS {
+    // typescript autocomplete for environment variabless
+    interface ProcessEnv {
+      // must be set by user
+      PGPASSFILE?: string;
+      // extracted from pgpassfile
+      PGHOST?: string;
+      PGPORT?: string;
+      PGDATABASE?: string;
+      PGUSER?: string;
+      PGPASSWORD?: string;
+    }
+  }
+}
+
+// If this file has no import/export statements (i.e. is a script)
+// convert it into a module by adding an empty export statement.
+export {};

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,12 +2,14 @@ import express from "express";
 import expressStaticGzip from "express-static-gzip";
 import { join } from "path";
 import { Pool } from "pg";
+import { setupDBCredentials } from "./setupDbCredentials";
+
 import getTablesFunction from "./routes/tables";
 import getTableHeadFromNameFunction from "./routes/tableHeadFromName";
 import getFDsFromTableNameFunction from "./routes/fdsFromTableName";
 import morgan from "morgan";
 
-const port = process.env["PORT"] || 80;
+setupDBCredentials();
 
 const pool = new Pool({});
 
@@ -27,6 +29,8 @@ app.get("/tables/:name/fds", getFDsFromTableNameFunction());
 app.use(
   expressStaticGzip(join(__dirname, "..", "frontend", "dist", "bcnfstar"), {})
 );
+
+const port = process.env["PORT"] || 80;
 
 const server = app.listen(port, () => {
   console.log(`bcnfstar server started on port ${port}`);

--- a/server/routes/metanomeAlgorithm.ts
+++ b/server/routes/metanomeAlgorithm.ts
@@ -1,11 +1,8 @@
 import { absoluteServerDir } from "../utils/files";
-import { config } from "dotenv";
 import { promisify } from "util";
 import { exec } from "child_process";
 import { join, dirname } from "path";
 import { toNamespacedPath } from "path/posix";
-
-config({ path: "../.env.local" });
 
 export const METANOME_CLI_JAR_PATH = "metanome/metanome-cli-1.1.0.jar";
 export const POSTGRES_JDBC_JAR_PATH = "metanome/postgresql-9.3-1102-jdbc41.jar";

--- a/server/routes/tables.ts
+++ b/server/routes/tables.ts
@@ -11,8 +11,11 @@ export default function getTablesFunction(pool: Pool): RequestHandler {
         data_type: string;
         column_name: string;
       }>(
-        "SELECT table_name, column_name, data_type FROM information_schema.columns WHERE table_schema=$1",
-        ["public"]
+        // the last line excludes system tables
+        `SELECT table_name, column_name, data_type 
+        FROM information_schema.columns 
+        WHERE table_schema NOT IN ('pg_catalog', 'information_schema')`,
+        []
       );
       const tempTables: Record<string, ITable> = {};
       for (const row of query_result.rows) {

--- a/server/setupDbCredentials.ts
+++ b/server/setupDbCredentials.ts
@@ -1,0 +1,26 @@
+import { config } from "dotenv";
+import { readFileSync } from "fs";
+
+export function setupDBCredentials() {
+  try {
+    config({ path: "../.env.local" });
+    // .pgpass format: hostname:port:database:username:password
+    const content = readFileSync(process.env.PGPASSFILE, "utf-8");
+    const [hostname, port, database, username, password] = content.split(":");
+
+    process.env.PGHOST = hostname;
+    process.env.PGPORT = port;
+    process.env.PGDATABASE = database;
+    process.env.PGUSER = username;
+    process.env.PGPASSWORD = password;
+  } catch (e) {
+    if (e.message.includes("ENOENT")) {
+      console.error(`Your database settings seem to be invalid. Create a pgpass file 
+(for more info, see https://www.postgresql.org/docs/9.3/libpq-pgpass.html)
+and save its location in a PGPASSFILE environment variable. You can do this by placing 
+the line 'PGPASSFILE=<path to file>' in a file called .env.local at the project root.
+      `);
+      process.exit();
+    } else throw e;
+  }
+}


### PR DESCRIPTION
Nur ne kleine Sache, wer will kann ja mal drübergucken :) Damit setzen wir die Umgebungsvariablen, sodass pg auf die in der pgpass definierten Credentials Zugriff hat. process.env ist global, es reicht also für alle routen das einmal am anfang hinzuzufügen. 