### PR TITLE
fix build crashing because of wrong version

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "@types/backbone": "^1.4.14",
     "@types/dagre": "^0.7.46",
     "@types/graphlib": "^2.1.8",
-    "@angular/localize": "^13.1.2",
+    "@angular/localize": "~13.1.2",
     "@types/jasmine": "~3.10.0",
     "@typescript-eslint/eslint-plugin": "5.3.0",
     "@typescript-eslint/parser": "5.3.0",


### PR DESCRIPTION
"^13.1.2" means 13.x.x and "~13.1.2" means 13.1.x. localize 13.2.1 was resolved with the old package.json, which is incompatible with all the other angular stuff being on 13.1