### PR TITLE
re-add ts-node - it made the pipeline fail^^

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -22,7 +22,8 @@
     "morgan": "^1.10.0",
     "mssql": "^7.3.0",
     "pg": "^8.7.1",
-    "promise-retry": "^2.0.1"
+    "promise-retry": "^2.0.1",
+    "ts-node": "^9.0.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",


### PR DESCRIPTION
This is the same version mentioned in ts-node-dev, so should be fine. It failed because in the CI, the devDependencies are only used for building the project, afterwards they are removed. ts-node-dev is rightfully a devDependency since it's not needed in production, but we need ts-node as a regular dependency