### PR TITLE
downgrade to last working version

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/platform-browser": "^13.1.2",
         "@angular/platform-browser-dynamic": "^13.1.2",
         "@angular/router": "^13.1.2",
-        "@sbb-esta/angular": "^13.0.0",
+        "@sbb-esta/angular": "~13.5.0",
         "bootstrap": "^5.1.3",
         "dagre": "^0.8.5",
         "file-saver": "^2.0.5",
@@ -3115,9 +3115,9 @@
       }
     },
     "node_modules/@sbb-esta/angular": {
-      "version": "13.11.0",
-      "resolved": "https://registry.npmjs.org/@sbb-esta/angular/-/angular-13.11.0.tgz",
-      "integrity": "sha512-2k04n8qn0WZI4PjmdNmtkcF2aliQN+uzrcpQD4nFzOT6NJoYVghsTr1E0IHrd7vi6YEqeWWXgBMrFcZ5WXrWhg==",
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@sbb-esta/angular/-/angular-13.5.0.tgz",
+      "integrity": "sha512-aJWmPtpZRKVVaw0ShifXRgUN9KikJ05bKAi7MHClloMw5plHt2Q2teaRmC2P1lu7l5O4g7XYBkMUzgfqXEI4FA==",
       "dependencies": {
         "@types/grecaptcha": "^2.0.36"
       },
@@ -3125,11 +3125,11 @@
         "node": ">=14.0.0 <17.0.0"
       },
       "peerDependencies": {
-        "@angular/cdk": "^13.0.0",
-        "@angular/common": "^13.0.0 || ^14.0.0",
-        "@angular/core": "^13.0.0 || ^14.0.0",
-        "@angular/forms": "^13.0.0 || ^14.0.0",
-        "@angular/router": "^13.0.0 || ^14.0.0"
+        "@angular/cdk": "^13.0.0-0",
+        "@angular/common": "^13.0.0-0 || ^14.0.0-0",
+        "@angular/core": "^13.0.0-0 || ^14.0.0-0",
+        "@angular/forms": "^13.0.0-0 || ^14.0.0-0",
+        "@angular/router": "^13.0.0-0 || ^14.0.0-0"
       }
     },
     "node_modules/@schematics/angular": {
@@ -15420,9 +15420,9 @@
       "peer": true
     },
     "@sbb-esta/angular": {
-      "version": "13.11.0",
-      "resolved": "https://registry.npmjs.org/@sbb-esta/angular/-/angular-13.11.0.tgz",
-      "integrity": "sha512-2k04n8qn0WZI4PjmdNmtkcF2aliQN+uzrcpQD4nFzOT6NJoYVghsTr1E0IHrd7vi6YEqeWWXgBMrFcZ5WXrWhg==",
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@sbb-esta/angular/-/angular-13.5.0.tgz",
+      "integrity": "sha512-aJWmPtpZRKVVaw0ShifXRgUN9KikJ05bKAi7MHClloMw5plHt2Q2teaRmC2P1lu7l5O4g7XYBkMUzgfqXEI4FA==",
       "requires": {
         "@types/grecaptcha": "^2.0.36"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,7 @@
     "@angular/platform-browser": "^13.1.2",
     "@angular/platform-browser-dynamic": "^13.1.2",
     "@angular/router": "^13.1.2",
-    "@sbb-esta/angular": "^13.0.0",
+    "@sbb-esta/angular": "~13.5.0",
     "bootstrap": "^5.1.3",
     "dagre": "^0.8.5",
     "file-saver": "^2.0.5",


### PR DESCRIPTION
downgrade sbb-angular to the last version compatible with bootstrap. in the medium term, we should revert this and remove bootstrap instead