### PR TITLE
escape schema name

### DIFF
--- a/server/db/PostgresSqlUtils.ts
+++ b/server/db/PostgresSqlUtils.ts
@@ -87,7 +87,7 @@ export default class PostgresSqlUtils extends SqlUtils {
     const tableExists = await this.tableExistsInSchema(schemaname, tablename);
     if (tableExists) {
       const query_result = await this.pool.query(
-        `SELECT * FROM ${schemaname}.${tablename} 
+        `SELECT * FROM "${schemaname}"."${tablename}"
         LIMIT ${limit} 
         OFFSET ${offset}`
       );


### PR DESCRIPTION
Damit Tobis Union-Schema nicht zur Zwiebel werden muss