### PR TITLE
fix possibly wrong pk after split

### DIFF
--- a/frontend/src/model/schema/methodObjects/Split.ts
+++ b/frontend/src/model/schema/methodObjects/Split.ts
@@ -26,7 +26,9 @@ export default class Split {
     this.projectFds(remaining);
     this.projectFds(generating);
 
-    remaining.pk = this.table.pk?.deepCopy();
+    remaining.pk = this.table.pk?.isSubsetOf(remaining.columns)
+      ? this.table.pk.deepCopy()
+      : undefined;
     generating.pk = this.fd.lhs.deepCopy();
 
     remaining.schemaName = this.table.schemaName;


### PR DESCRIPTION
Wir haben zwar eine Warnung angezeigt, wenn der PK beim Split kaputt gehen würde, aber wenn man dann splittet wurde der PK trotzdem fälschlich übernommen.