### PR TITLE
Colourful Dimensions

### DIFF
--- a/frontend/src/app/components/graph/graph-element/graph-element.component.css
+++ b/frontend/src/app/components/graph/graph-element/graph-element.component.css
@@ -24,17 +24,21 @@
   text-align: center;
   vertical-align: middle;
   display: inline-block;
-  background-color: #f27e00;
+  background-color: #ffde15;
   font-weight: bold;
   color: white;
 }
 
-.dimension {
+.fact {
   background-color: #ffde1577 !important;
 }
 
-.fact {
+.directDimension {
   background-color: #f27e0077 !important;
+}
+
+.dimension {
+  background-color: #e84e10df !important;
 }
 
 .pk {
@@ -44,7 +48,6 @@
 .fk {
   font-style: italic;
 }
-
 
 .highlighted {
   font-weight: bold;

--- a/frontend/src/app/components/graph/graph-element/graph-element.component.html
+++ b/frontend/src/app/components/graph/graph-element/graph-element.component.html
@@ -12,7 +12,8 @@
     [sbbTooltip]="table.fullName"
     [ngClass]="{
       fact: isFact(),
-      dimension: isDimension(),
+      directDimension: isDirectDimension(),
+      dimension: isDimension() && !isDirectDimension(),
       'table-head-highlight': schemaService.selectedTable === table
     }"
   >

--- a/frontend/src/app/components/graph/graph-element/graph-element.component.ts
+++ b/frontend/src/app/components/graph/graph-element/graph-element.component.ts
@@ -46,6 +46,13 @@ export class GraphElementComponent {
     );
   }
 
+  public isDirectDimension(): boolean {
+    return (
+      this.schemaService.starMode &&
+      this.schemaService.schema.isDirectDimension(this.table)
+    );
+  }
+
   public isDimension(): boolean {
     return (
       this.schemaService.starMode &&

--- a/frontend/src/model/schema/Schema.ts
+++ b/frontend/src/model/schema/Schema.ts
@@ -202,6 +202,12 @@ export default class Schema {
     return this.referencesOf(table, onlyDisplayed).length == 0;
   }
 
+  public isDirectDimension(table: Table): boolean {
+    return this.referencesOf(table, true).some((reference) =>
+      this.isFact(reference.referencing, true)
+    );
+  }
+
   /**
    * filters out routes from routesFromFactTo(table) that consist of less than 2 TableRelationships
    * or routes that would add no extra information to the fact table when joined completely


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/42703506/174078277-499a59ef-7743-4753-8a36-0775ca2745f9.png)
Die direkten Dimensionen sind jetzt orange und die noch nicht direkten Dimensionen rot. So sieht man leichter, dass man sich nur noch um die roten Tabellen kümmern muss um einen Star zu bauen.