### PR TITLE
fix font overhang in graph element

### DIFF
--- a/frontend/src/app/components/graph/schema-graph/schema-graph.component.ts
+++ b/frontend/src/app/components/graph/schema-graph/schema-graph.component.ts
@@ -26,7 +26,7 @@ enum PortSide {
 export class SchemaGraphComponent implements AfterContentInit {
   protected panzoomTransform: Transform = { x: 0, y: 0, scale: 1 };
 
-  protected portDiameter = 22.5;
+  protected columnHeight = 23;
 
   public graphStorage = new Map<Table, GraphStorageItem>();
 
@@ -85,7 +85,7 @@ export class SchemaGraphComponent implements AfterContentInit {
       graphlib,
       nodeSep: 40,
       // prevent left ports from being cut off
-      marginX: this.portDiameter / 2,
+      marginX: this.columnHeight / 2,
       edgeSep: 80,
       rankSep: 200,
       rankDir: 'LR',
@@ -150,7 +150,7 @@ export class SchemaGraphComponent implements AfterContentInit {
       jointjsEl.resize(
         this.elementWidth,
         60 +
-          this.portDiameter *
+          this.columnHeight *
             this.schemaService.schema.displayedColumnsOf(table).length
       );
       this.graphStorage.set(table, {
@@ -264,8 +264,8 @@ export class SchemaGraphComponent implements AfterContentInit {
     side: PortSide;
   }) {
     const cx = side == PortSide.Left ? 0 : this.elementWidth;
-    return `<circle r="${this.portDiameter / 2}" cx="${cx}" cy="${
-      this.graphElementHeaderHeight + this.portDiameter * (counter + 0.5)
+    return `<circle r="${this.columnHeight / 2}" cx="${cx}" cy="${
+      this.graphElementHeaderHeight + this.columnHeight * (counter + 0.5)
     }" strokegit ="green" fill="white"/>`;
   }
 


### PR DESCRIPTION
I recommend denormalized_data for checking, as it has the most columns and therefore the biggest issue. One row is exactly 23px both on firefox and chromium