### PR TITLE
Fix/filter fdcluster waiting

### DIFF
--- a/cypress/e2e/frontend/components/metanome-settings.cy.ts
+++ b/cypress/e2e/frontend/components/metanome-settings.cy.ts
@@ -474,7 +474,7 @@ describe("The metanome settings dialog", () => {
     ).should("contain", "SAMPLE_GOAL: 600", { force: true });
   });
 
-  it("does not calculate fds and inds when using use no Metanome result tab", () => {
+  it.only("does not calculate fds and inds when using use no Metanome result tab", () => {
     cy.get('.sbb-toggle-option:contains("Use no Metanome result")').click({
       multiple: true,
     });

--- a/cypress/e2e/frontend/components/metanome-settings.cy.ts
+++ b/cypress/e2e/frontend/components/metanome-settings.cy.ts
@@ -474,7 +474,7 @@ describe("The metanome settings dialog", () => {
     ).should("contain", "SAMPLE_GOAL: 600", { force: true });
   });
 
-  it.only("does not calculate fds and inds when using use no Metanome result tab", () => {
+  it("does not calculate fds and inds when using use no Metanome result tab", () => {
     cy.get('.sbb-toggle-option:contains("Use no Metanome result")').click({
       multiple: true,
     });

--- a/frontend/src/app/components/tabbar/contained-subtables/contained-subtables.component.html
+++ b/frontend/src/app/components/tabbar/contained-subtables/contained-subtables.component.html
@@ -7,6 +7,7 @@
       multiple
       placeholder="Filter columns"
       [(ngModel)]="_fdClusterFilter"
+      (selectionChange)="selectionChanged()"
     >
       <app-sbb-option-all
         [(current)]="_fdClusterFilter"
@@ -20,16 +21,16 @@
       >
     </sbb-select>
     <br />
-    <sbb-accordion *ngIf="fdClusters().length > 0; else noClusters">
+    <sbb-accordion *ngIf="cachedClusters.length > 0; else noClusters">
       <sbb-paginator
         (page)="changePage($event)"
         [pageSize]="pageSize"
-        [length]="fdClusters().length"
+        [length]="cachedClusters.length"
       >
       </sbb-paginator>
       <sbb-expansion-panel
         *ngFor="
-          let cluster of fdClusters().slice(
+          let cluster of cachedClusters.slice(
             page * pageSize,
             (page + 1) * pageSize
           )

--- a/frontend/src/app/components/tabbar/contained-subtables/contained-subtables.component.html
+++ b/frontend/src/app/components/tabbar/contained-subtables/contained-subtables.component.html
@@ -7,7 +7,7 @@
       multiple
       placeholder="Filter columns"
       [(ngModel)]="_fdClusterFilter"
-      (selectionChange)="selectionChanged()"
+      (selectionChange)="updateFdClusters()"
     >
       <app-sbb-option-all
         [(current)]="_fdClusterFilter"

--- a/frontend/src/app/components/tabbar/contained-subtables/contained-subtables.component.ts
+++ b/frontend/src/app/components/tabbar/contained-subtables/contained-subtables.component.ts
@@ -35,6 +35,7 @@ export class ContainedSubtablesComponent {
   constructor(public schemaService: SchemaService, private dialog: SbbDialog) {
     this.schemaService.selectedTableChanged.subscribe(() => {
       this._fdClusterFilter = [];
+      this.updateFdClusters();
     });
   }
 
@@ -57,11 +58,6 @@ export class ContainedSubtablesComponent {
   }
 
   public cachedClusters = this.table.rankedFdClusters();
-
-  public selectionChanged() {
-    this.updateFdClusters();
-  }
-
   
   /**
    * 

--- a/frontend/src/model/schema/Table.ts
+++ b/frontend/src/model/schema/Table.ts
@@ -480,7 +480,7 @@ export default class Table extends BasicTable {
   /**
    * calculates for every fd in the clusters a ranking score
    * @param fdClusters 
-   * @returns fdc lusters with fds with ranking scores
+   * @returns fd clusters with fds with ranking scores
    */
   private scoreFdInFdClusters(fdClusters: Array<FdCluster>): Array<FdCluster> {
     fdClusters.forEach((cluster) =>

--- a/frontend/src/model/schema/methodObjects/FdScore.ts
+++ b/frontend/src/model/schema/methodObjects/FdScore.ts
@@ -44,14 +44,20 @@ export default class FdScore {
    * @returns all single scores
    */
   public testingScore() {
+    return Object.fromEntries(Object.entries(this.allScores()).map(
+      ([type, scoreFunction]) => [type, scoreFunction.bind(this)()]
+    ))
+  }
+
+  private allScores(): Record<string, () => number> {
     return {
-      length: this.fdLengthScore(),
-      keyValue: this.fdKeyValueScore(),
-      position: this.fdPositionScore(),
-      redundanceTeam: this.fdRedundanceScoreTeam(),
-      redundanceWeiLink: this.fdRedundanceScoreWeiLink(),
-      redundanceMetanome: this.fdRedundanceScoreMetanome(),
-      similarity: this.fdSimilarityScore(),
+      length: this.fdLengthScore,
+      keyValue: this.fdKeyValueScore,
+      position: this.fdPositionScore,
+      redundanceTeam: this.fdRedundanceScoreTeam,
+      redundanceWeiLink: this.fdRedundanceScoreWeiLink,
+      redundanceMetanome: this.fdRedundanceScoreMetanome,
+      similarity: this.fdSimilarityScore
     };
   }
 
@@ -60,37 +66,12 @@ export default class FdScore {
    * @returns a ranking score used different ranking approaches 
    */
   private calculate(): number {
-    let lengthScore: number = (window as any).DEFAULT_RANKING_WEIGHTS.length != 0 
-      ? (window as any).DEFAULT_RANKING_WEIGHTS.length * this.fdLengthScore()
-      : 0;
-    let keyValueScore: number = (window as any).DEFAULT_RANKING_WEIGHTS.keyValue != 0 
-      ? (window as any).DEFAULT_RANKING_WEIGHTS.keyValue * this.fdKeyValueScore()
-      : 0;
-    let positionScore: number = (window as any).DEFAULT_RANKING_WEIGHTS.position != 0 
-      ? (window as any).DEFAULT_RANKING_WEIGHTS.position * this.fdPositionScore()
-      : 0;
-    let redundanceTeamScore: number = (window as any).DEFAULT_RANKING_WEIGHTS.redundanceTeam != 0 
-      ? (window as any).DEFAULT_RANKING_WEIGHTS.redundanceTeam * this.fdRedundanceScoreTeam()
-      : 0;
-    let redundanceWeiLinkScore: number = (window as any).DEFAULT_RANKING_WEIGHTS.redundanceWeiLink != 0 
-      ? (window as any).DEFAULT_RANKING_WEIGHTS.redundanceWeiLink * this.fdRedundanceScoreWeiLink()
-      : 0;
-    let redundanceMetanomeScore: number = (window as any).DEFAULT_RANKING_WEIGHTS.redundanceMetanome != 0 
-      ? (window as any).DEFAULT_RANKING_WEIGHTS.redundanceMetanome * this.fdRedundanceScoreMetanome()
-      : 0;
-    let similarityScore: number = (window as any).DEFAULT_RANKING_WEIGHTS.similarity != 0 
-      ? (window as any).DEFAULT_RANKING_WEIGHTS.similarity * this.fdSimilarityScore()
-      : 0;
-
-    return (
-      lengthScore +
-      keyValueScore +
-      positionScore +
-      redundanceTeamScore +
-      redundanceWeiLinkScore +
-      redundanceMetanomeScore +
-      similarityScore
-    );
+    let score = 0
+    for (const [weightName, scoreFunction] of Object.entries(this.allScores())) {
+      const weight: number = (window as any).DEFAULT_RANKING_WEIGHTS[weightName] ?? 0
+      if (weight !== 0) score += weight * scoreFunction.bind(this)()
+    }
+    return score
   }
 
   /**

--- a/frontend/src/model/schema/methodObjects/FdScore.ts
+++ b/frontend/src/model/schema/methodObjects/FdScore.ts
@@ -60,20 +60,36 @@ export default class FdScore {
    * @returns a ranking score used different ranking approaches 
    */
   private calculate(): number {
+    let lengthScore: number = (window as any).DEFAULT_RANKING_WEIGHTS.length != 0 
+      ? (window as any).DEFAULT_RANKING_WEIGHTS.length * this.fdLengthScore()
+      : 0;
+    let keyValueScore: number = (window as any).DEFAULT_RANKING_WEIGHTS.keyValue != 0 
+      ? (window as any).DEFAULT_RANKING_WEIGHTS.keyValue * this.fdKeyValueScore()
+      : 0;
+    let positionScore: number = (window as any).DEFAULT_RANKING_WEIGHTS.position != 0 
+      ? (window as any).DEFAULT_RANKING_WEIGHTS.position * this.fdPositionScore()
+      : 0;
+    let redundanceTeamScore: number = (window as any).DEFAULT_RANKING_WEIGHTS.redundanceTeam != 0 
+      ? (window as any).DEFAULT_RANKING_WEIGHTS.redundanceTeam * this.fdRedundanceScoreTeam()
+      : 0;
+    let redundanceWeiLinkScore: number = (window as any).DEFAULT_RANKING_WEIGHTS.redundanceWeiLink != 0 
+      ? (window as any).DEFAULT_RANKING_WEIGHTS.redundanceWeiLink * this.fdRedundanceScoreWeiLink()
+      : 0;
+    let redundanceMetanomeScore: number = (window as any).DEFAULT_RANKING_WEIGHTS.redundanceMetanome != 0 
+      ? (window as any).DEFAULT_RANKING_WEIGHTS.redundanceMetanome * this.fdRedundanceScoreMetanome()
+      : 0;
+    let similarityScore: number = (window as any).DEFAULT_RANKING_WEIGHTS.similarity != 0 
+      ? (window as any).DEFAULT_RANKING_WEIGHTS.similarity * this.fdSimilarityScore()
+      : 0;
+
     return (
-      (window as any).DEFAULT_RANKING_WEIGHTS.length * this.fdLengthScore() +
-      (window as any).DEFAULT_RANKING_WEIGHTS.keyValue *
-        this.fdKeyValueScore() +
-      (window as any).DEFAULT_RANKING_WEIGHTS.position *
-        this.fdPositionScore() +
-      (window as any).DEFAULT_RANKING_WEIGHTS.redundanceTeam *
-        this.fdRedundanceScoreTeam() +
-      (window as any).DEFAULT_RANKING_WEIGHTS.redundanceWeiLink *
-        this.fdRedundanceScoreWeiLink() +
-      (window as any).DEFAULT_RANKING_WEIGHTS.redundanceMetanome *
-        this.fdRedundanceScoreMetanome() +
-      (window as any).DEFAULT_RANKING_WEIGHTS.similarity *
-        this.fdSimilarityScore()
+      lengthScore +
+      keyValueScore +
+      positionScore +
+      redundanceTeamScore +
+      redundanceWeiLinkScore +
+      redundanceMetanomeScore +
+      similarityScore
     );
   }
 

--- a/frontend/src/model/schema/methodObjects/FdScore.ts
+++ b/frontend/src/model/schema/methodObjects/FdScore.ts
@@ -40,17 +40,17 @@ export default class FdScore {
   }
 
   /**
-   * should be only used for testing
+   * should be only used for (automatic) testing
    * @returns all single scores
    */
   public testingScore() {
-    return Object.fromEntries(Object.entries(this.allScores()).map(
-      ([type, scoreFunction]) => [type, scoreFunction.bind(this)()]
+    return Object.fromEntries(Object.entries(this.allScoreFunctions()).map(
+      ([type, scoreFunction]) => [type, scoreFunction()]
     ))
   }
 
-  private allScores(): Record<string, () => number> {
-    return {
+  private allScoreFunctions(): Record<string, () => number> {
+    const functions: Record<string, () => number> = {
       length: this.fdLengthScore,
       keyValue: this.fdKeyValueScore,
       position: this.fdPositionScore,
@@ -59,6 +59,10 @@ export default class FdScore {
       redundanceMetanome: this.fdRedundanceScoreMetanome,
       similarity: this.fdSimilarityScore
     };
+    for(const weightName in functions)
+      functions[weightName] = functions[weightName].bind(this)
+
+    return functions;
   }
 
   /**
@@ -67,9 +71,9 @@ export default class FdScore {
    */
   private calculate(): number {
     let score = 0
-    for (const [weightName, scoreFunction] of Object.entries(this.allScores())) {
+    for (const [weightName, scoreFunction] of Object.entries(this.allScoreFunctions())) {
       const weight: number = (window as any).DEFAULT_RANKING_WEIGHTS[weightName] ?? 0
-      if (weight !== 0) score += weight * scoreFunction.bind(this)()
+      if (weight !== 0) score += weight * scoreFunction()
     }
     return score
   }
@@ -89,7 +93,7 @@ export default class FdScore {
   private rhsLengthScore(): number {
     return this.table.numColumns > 2
       ? this.fd.rhs.copy().setMinus(this.fd.lhs).cardinality /
-          (this.table.numColumns - 2)
+      (this.table.numColumns - 2)
       : 0;
   }
 


### PR DESCRIPTION
related to #374 

1. For calculating the fd ranking always all scores were calculated, also if they are not used. This was very time expensive. Now a fd score is only calculated if it is used. 
2. For filtering the fd clusters in frontend, the function fdClusters() is used. In the function were also called some expensive functions like filter or map that always has to look to all components. Because fdClusters was called from an UI component, it was called again and again. This leads to the fact that one can move tables on UI only jerkily. Now (update)FdClusters() is only called when the filter selection changes and it updates a new variable cachedClusters with new filter selection.  