### PR TITLE
Split null

### DIFF
--- a/frontend/src/app/components/export/persist-schema/persist-schema.component.html
+++ b/frontend/src/app/components/export/persist-schema/persist-schema.component.html
@@ -1,3 +1,13 @@
+<div>Null Constraints in exported schema:</div>
+<sbb-toggle [(ngModel)]="constraintPolicy">
+  <sbb-toggle-option label="minimal" value="minimal"></sbb-toggle-option>
+  <sbb-toggle-option
+    label="use original constraints"
+    value="schema"
+  ></sbb-toggle-option>
+  <sbb-toggle-option label="maximal" value="maximal"></sbb-toggle-option>
+</sbb-toggle>
+
 <div class="grid-container mx-1">
   <input
     class="me-1"

--- a/frontend/src/app/components/export/persist-schema/persist-schema.component.ts
+++ b/frontend/src/app/components/export/persist-schema/persist-schema.component.ts
@@ -13,6 +13,7 @@ import { DatabaseService } from '../../../database.service';
 })
 export class PersistSchemaComponent {
   public schemaName: string = '';
+  public constraintPolicy: string = 'maximal';
 
   constructor(
     public dataService: DatabaseService,
@@ -32,7 +33,10 @@ export class PersistSchemaComponent {
 
   public async persistSchema(): Promise<string> {
     const persisting = await this.initPersisting();
-    return persisting.createSQL(this.schemaService.schema);
+    return persisting.createSQL(
+      this.schemaService.schema,
+      this.constraintPolicy
+    );
   }
 
   async download(): Promise<void> {

--- a/frontend/src/app/components/operation-dialogs/split-dialog/split-dialog.component.html
+++ b/frontend/src/app/components/operation-dialogs/split-dialog/split-dialog.component.html
@@ -60,6 +60,12 @@
       </li>
     </ul>
   </div>
+
+  <div *ngIf="useNull" class="violation">
+    The key of the created table would contain null values. Please specify a
+    value with which to replace the null values.
+  </div>
+
   <div sbbDialogActions>
     <button
       sbb-button

--- a/frontend/src/app/components/operation-dialogs/split-dialog/split-dialog.component.html
+++ b/frontend/src/app/components/operation-dialogs/split-dialog/split-dialog.component.html
@@ -61,9 +61,30 @@
     </ul>
   </div>
 
-  <div *ngIf="useNull" class="violation">
+  <div *ngIf="nullCols && nullCols.length > 0" class="violation">
     The key of the created table would contain null values. Please specify a
     value with which to replace the null values.
+    <br />
+    <table>
+      <tr>
+        <th>name</th>
+        <th>datatype</th>
+        <th>substitute</th>
+      </tr>
+      <tr *ngFor="let col of nullCols">
+        <td>{{ col.name }}</td>
+        <td>{{ col.dataType }}</td>
+        <td>
+          <input
+            type="text"
+            sbbInput
+            placeholder="substitute for null values"
+            [ngModel]="nullSubstitutes.get(col)"
+            (ngModelChange)="nullSubstitutes.set(col, $event)"
+          />
+        </td>
+      </tr>
+    </table>
   </div>
 
   <div sbbDialogActions>

--- a/frontend/src/app/components/operation-dialogs/split-dialog/split-dialog.component.html
+++ b/frontend/src/app/components/operation-dialogs/split-dialog/split-dialog.component.html
@@ -81,10 +81,21 @@
             placeholder="substitute for null values"
             [ngModel]="nullSubstitutes.get(col)"
             (ngModelChange)="nullSubstitutes.set(col, $event)"
+            (ngModelChange)="nullSubstituteCheckValid = false"
           />
+        </td>
+        <td>
+          {{ nullSubstituteErrors.get(col) }}
         </td>
       </tr>
     </table>
+    <button
+      sbb-button
+      [disabled]="nullSubstituteCheckValid"
+      (click)="checkNullSubstitutes()"
+    >
+      Check Substitutes
+    </button>
   </div>
 
   <div sbbDialogActions>

--- a/frontend/src/app/components/operation-dialogs/split-dialog/split-dialog.component.ts
+++ b/frontend/src/app/components/operation-dialogs/split-dialog/split-dialog.component.ts
@@ -1,3 +1,4 @@
+import { NotNullDataQuery } from '@/src/app/dataquery';
 import { SchemaService } from '@/src/app/schema.service';
 import Column from '@/src/model/schema/Column';
 import ColumnCombination from '@/src/model/schema/ColumnCombination';
@@ -30,6 +31,7 @@ export class SplitDialogComponent {
   public pkViolation!: boolean;
   public fkViolations!: Array<TableRelationship>;
   public referenceViolations!: Array<TableRelationship>;
+  public useNull!: boolean;
 
   public minimalDeterminants!: Array<ColumnCombination>;
   public hull!: ColumnCombination;
@@ -59,6 +61,7 @@ export class SplitDialogComponent {
     });
     this.tableName = this.fd.lhs.columnNames().join('_').substring(0, 50);
     this.updateViolations();
+    this.checkUseNull();
   }
 
   public get table() {
@@ -84,8 +87,8 @@ export class SplitDialogComponent {
     return !this.minimalDeterminants.some((det) => det.equals(this.fd.lhs));
   }
 
-  public async updateViolations() {
-    this.minimalDeterminants = await this.table.minimalDeterminantsOf(
+  public updateViolations() {
+    this.minimalDeterminants = this.table.minimalDeterminantsOf(
       this.selectedColumnsCC()
     );
     this.pkViolation = this.schemaService.schema.fdSplitPKViolationOf(
@@ -101,6 +104,14 @@ export class SplitDialogComponent {
         this.fd,
         this.table
       );
+  }
+
+  public async checkUseNull() {
+    const dataQuery: NotNullDataQuery = await NotNullDataQuery.Create(
+      this.table,
+      this.fd.lhs.asArray()
+    );
+    this.useNull = !(await dataQuery.result());
   }
 
   public isFullyDetermined() {

--- a/frontend/src/app/components/operation-dialogs/split-dialog/split-dialog.component.ts
+++ b/frontend/src/app/components/operation-dialogs/split-dialog/split-dialog.component.ts
@@ -117,7 +117,7 @@ export class SplitDialogComponent {
     this.nullSubstituteErrors = new Map<Column, string>();
 
     for (let column of this.fd.lhs) {
-      if (column.sourceColumn.nullable) {
+      if (column.sourceColumn.safeInferredNullable) {
         this.nullCols.push(column);
         this.nullSubstitutes.set(column, column.nullSubstitute ?? '');
       }

--- a/frontend/src/app/components/tabbar/contained-subtables/contained-subtables.component.ts
+++ b/frontend/src/app/components/tabbar/contained-subtables/contained-subtables.component.ts
@@ -57,7 +57,7 @@ export class ContainedSubtablesComponent {
   }
 
   /**
-   * 
+   *
    * @returns fd clusters (further infos in Table.ts) eventually filterd by columns from user input
    */
   public fdClusters(): Array<FdCluster> {
@@ -97,7 +97,11 @@ export class ContainedSubtablesComponent {
     switch (response.type) {
       case 'fdSplit': {
         const fdResponse = response as FdSplitResponse;
-        this.schemaService.split(fdResponse.fd, fdResponse.name);
+        this.schemaService.split(
+          fdResponse.fd,
+          fdResponse.nullSubstitutes,
+          fdResponse.name
+        );
         break;
       }
       case 'changeKey': {

--- a/frontend/src/app/dataquery.ts
+++ b/frontend/src/app/dataquery.ts
@@ -249,16 +249,13 @@ export class ViolatingFDRowsDataQuery extends DataQuery {
 }
 
 export class NotNullDataQuery extends Query {
-  public static async Create(
-    table: Table,
-    cols: Array<Column>
-  ): Promise<NotNullDataQuery> {
-    const notNullDataQuery = new NotNullDataQuery(table, cols);
+  public static async Create(col: SourceColumn): Promise<NotNullDataQuery> {
+    const notNullDataQuery = new NotNullDataQuery(col);
     await notNullDataQuery.initPersisting();
     return notNullDataQuery;
   }
 
-  private constructor(protected table: Table, protected cols: Array<Column>) {
+  private constructor(protected col: SourceColumn) {
     super();
   }
 
@@ -270,13 +267,9 @@ export class NotNullDataQuery extends Query {
 
   private body(): IRequestBodyNotNull {
     return {
-      tableSql: this.SqlGeneration!.selectStatement(
-        this.table,
-        this.table.columns.asArray(),
-        [],
-        true
-      ),
-      expectedKey: this.cols.map((c) => c.name),
+      schemaName: this.col.table.schemaName,
+      tableName: this.col.table.name,
+      columnName: this.col.name,
     };
   }
 }

--- a/frontend/src/app/integration.service.ts
+++ b/frontend/src/app/integration.service.ts
@@ -213,8 +213,13 @@ export class IntegrationService {
       '__schema_matching_temp_target'
     );
     const body: ISchemaMatchingRequest = {
-      srcSql: srcPersister.tableCreation(srcSchema, src, true),
-      targetSql: targetPersister.tableCreation(targetSchema, target, true),
+      srcSql: srcPersister.tableCreation(srcSchema, 'maximal', src, true),
+      targetSql: targetPersister.tableCreation(
+        targetSchema,
+        'maximal',
+        target,
+        true
+      ),
       thesaurus: this.thesaurus,
     };
     const result = await firstValueFrom(

--- a/frontend/src/app/schema.service.ts
+++ b/frontend/src/app/schema.service.ts
@@ -338,7 +338,7 @@ export class SchemaService {
 
     if (!rowCount) {
       const error_message =
-        'There was a backend error while checking this IND. Check the browser and server logs for details';
+        'There was a backend error while checking this FD. Check the browser and server logs for details';
       this.notification.open(error_message, { type: 'error' });
       throw new Error(error_message);
     }

--- a/frontend/src/app/schema.service.ts
+++ b/frontend/src/app/schema.service.ts
@@ -195,10 +195,20 @@ export class SchemaService {
     this.notifyAboutSchemaChanges();
   }
 
-  public async split(fd: FunctionalDependency, name?: string) {
+  public async split(
+    fd: FunctionalDependency,
+    nullSubstitutes: Map<Column, string>,
+    name?: string
+  ) {
     if (!(this.selectedTable instanceof Table))
       throw Error('splitting not implemented for unioned tables');
-    let command = new SplitCommand(this._schema, this.selectedTable!, fd, name);
+    let command = new SplitCommand(
+      this._schema,
+      this.selectedTable!,
+      fd,
+      nullSubstitutes,
+      name
+    );
 
     command.onDo = () => (this.selectedTable = command.children![0]);
     command.onUndo = () => (this.selectedTable = command.table);

--- a/frontend/src/model/commands/SplitCommand.ts
+++ b/frontend/src/model/commands/SplitCommand.ts
@@ -1,3 +1,4 @@
+import Column from '../schema/Column';
 import FunctionalDependency from '../schema/FunctionalDependency';
 import Split from '../schema/methodObjects/Split';
 import Schema from '../schema/Schema';
@@ -13,6 +14,7 @@ export default class SplitCommand extends Command {
     private schema: Schema,
     public table: Table,
     private fd: FunctionalDependency,
+    private nullSubstitutes?: Map<Column, string>,
     generatingName?: string
   ) {
     super();
@@ -23,6 +25,7 @@ export default class SplitCommand extends Command {
     this.children = new Split(
       this.table,
       this.fd,
+      this.nullSubstitutes,
       this.generatingName
     ).newTables;
     this._redo();

--- a/frontend/src/model/schema/Column.ts
+++ b/frontend/src/model/schema/Column.ts
@@ -16,6 +16,7 @@ export default class Column implements BasicColumn {
   public constructor(
     public sourceTableInstance: SourceTableInstance,
     public sourceColumn: SourceColumn,
+    public nullSubstitute?: string,
     public userAlias?: string
   ) {}
 
@@ -65,6 +66,7 @@ export default class Column implements BasicColumn {
     let col = new Column(
       this.sourceTableInstance,
       this.sourceColumn,
+      this.nullSubstitute,
       this.userAlias
     );
     // for value ranking, sufficient to update maxValues after splitting
@@ -77,7 +79,7 @@ export default class Column implements BasicColumn {
   }
 
   public get nullable() {
-    return this.sourceColumn.nullable;
+    return this.sourceColumn.nullable && !this.nullSubstitute;
   }
 
   public get dataTypeString() {
@@ -101,6 +103,7 @@ export default class Column implements BasicColumn {
     return new Column(
       mapping.get(this.sourceTableInstance) || this.sourceTableInstance,
       this.sourceColumn,
+      this.nullSubstitute,
       this.userAlias
     );
   }

--- a/frontend/src/model/schema/Column.ts
+++ b/frontend/src/model/schema/Column.ts
@@ -79,7 +79,17 @@ export default class Column implements BasicColumn {
   }
 
   public get nullable() {
-    return this.sourceColumn.nullable && !this.nullSubstitute;
+    return this.nullableConstraint('maximal');
+  }
+
+  public nullableConstraint(constraintPolicy: string) {
+    if (this.nullSubstitute) return false;
+    if (constraintPolicy == 'minimal') return true;
+    else if (constraintPolicy == 'schema')
+      return this.sourceColumn.schemaNullable;
+    else if (constraintPolicy == 'maximal')
+      return this.sourceColumn.safeInferredNullable;
+    throw Error();
   }
 
   public get dataTypeString() {

--- a/frontend/src/model/schema/Schema.ts
+++ b/frontend/src/model/schema/Schema.ts
@@ -749,7 +749,7 @@ export default class Schema {
       this.fdSplitFKViolationsOf(fd, table).length == 0 &&
       this.fdSplitReferenceViolationsOf(fd, table).length == 0 &&
       !this.fdSplitPKViolationOf(fd, table) &&
-      fd.lhs.asArray().every((col) => !col.sourceColumn.nullable)
+      fd.lhs.asArray().every((col) => !col.sourceColumn.safeInferredNullable)
     );
   }
 

--- a/frontend/src/model/schema/Schema.ts
+++ b/frontend/src/model/schema/Schema.ts
@@ -748,7 +748,8 @@ export default class Schema {
     return (
       this.fdSplitFKViolationsOf(fd, table).length == 0 &&
       this.fdSplitReferenceViolationsOf(fd, table).length == 0 &&
-      !this.fdSplitPKViolationOf(fd, table)
+      !this.fdSplitPKViolationOf(fd, table) &&
+      fd.lhs.asArray().every((col) => !col.sourceColumn.nullable)
     );
   }
 

--- a/frontend/src/model/schema/SourceColumn.ts
+++ b/frontend/src/model/schema/SourceColumn.ts
@@ -8,11 +8,19 @@ export default class SourceColumn {
     public name: string,
     public table: SourceTable,
     public dataType: string,
-    public nullable: boolean
+    public schemaNullable: boolean,
+    public inferredNullable?: boolean
   ) {}
 
   public equals(other: SourceColumn): boolean {
     if (this == other) return true;
     return this.name == other.name && this.table.equals(other.table);
+  }
+
+  /**
+   * Use this instead of inferredNullable to avoid having errors because of missing database connection.
+   */
+  public get safeInferredNullable() {
+    return this.inferredNullable ?? this.schemaNullable;
   }
 }

--- a/frontend/src/model/schema/methodObjects/SaveSchemaState.ts
+++ b/frontend/src/model/schema/methodObjects/SaveSchemaState.ts
@@ -99,7 +99,8 @@ interface JSONSourceColumn {
   name: string;
   table: JSONSourceTable;
   dataType: string;
-  nullable: boolean;
+  schemaNullable: boolean;
+  inferredNullable?: boolean;
 }
 
 interface JSONSourceTable {
@@ -351,7 +352,8 @@ export default class SaveSchemaState {
       sc.name,
       newSourceTable,
       sc.dataType,
-      sc.nullable
+      sc.schemaNullable,
+      sc.inferredNullable
     );
 
     let existingCol = this.existingSourceColumns.find((other) =>

--- a/frontend/src/model/schema/methodObjects/SaveSchemaState.ts
+++ b/frontend/src/model/schema/methodObjects/SaveSchemaState.ts
@@ -81,6 +81,7 @@ interface JSONColumnCombination {
 interface JSONColumn {
   sourceTableInstance: JSONSourceTableInstance;
   sourceColumn: JSONSourceColumn;
+  nullSubstitute: string;
   userAlias?: string;
   includeSourceName: boolean;
   _maxValue: number;
@@ -286,6 +287,7 @@ export default class SaveSchemaState {
     let column = new Column(
       this.findSourceTableInstance(col.sourceTableInstance, table.sources),
       this.parseSourceColumn(col.sourceColumn),
+      col.nullSubstitute,
       col.userAlias
     );
     column.includeSourceName = col.includeSourceName;

--- a/frontend/src/model/schema/methodObjects/Split.ts
+++ b/frontend/src/model/schema/methodObjects/Split.ts
@@ -12,12 +12,16 @@ export default class Split {
   public constructor(
     private table: Table,
     private fd: FunctionalDependency,
+    private nullSubstitutes?: Map<Column, string>,
     private generatingName?: string
   ) {
     this.split();
   }
 
   private split() {
+    for (let col of this.nullSubstitutes?.keys() ?? []) {
+      col.nullSubstitute = this.nullSubstitutes?.get(col);
+    }
     let remaining: Table = new Delete(
       this.table,
       this.fd.rhs.copy().setMinus(this.fd.lhs)

--- a/frontend/src/model/schema/persisting/SQLPersisting.ts
+++ b/frontend/src/model/schema/persisting/SQLPersisting.ts
@@ -298,9 +298,14 @@ ALTER TABLE ${this.tableIdentifier(
     dataType: string = ''
   ): string {
     if (column == null) return ` CAST (null AS ${dataType}) `;
-    return `${this.escape(column.sourceTableInstance.alias)}.${this.escape(
-      column.sourceColumn.name
-    )}`;
+    let identifier = `${this.escape(
+      column.sourceTableInstance.alias
+    )}.${this.escape(column.sourceColumn.name)}`;
+    if (column.nullSubstitute) {
+      return `COALESCE(${identifier}, '${column.nullSubstitute}')`;
+    } else {
+      return identifier;
+    }
   }
 
   public abstract surrogateKeyString(name: string): string;

--- a/frontend/src/model/schema/persisting/SQLPersisting.ts
+++ b/frontend/src/model/schema/persisting/SQLPersisting.ts
@@ -13,10 +13,10 @@ export default abstract class SQLPersisting {
 
   public abstract escape(str: string): string;
 
-  public createSQL(schema: Schema): string {
+  public createSQL(schema: Schema, constraintPolicy: string): string {
     let SQL = '';
     SQL += this.schemaPreparation(schema);
-    SQL += this.tableCreation(schema);
+    SQL += this.tableCreation(schema, constraintPolicy);
     SQL += this.dataTransfer([...schema.tables]);
     SQL += this.primaryKeys([...schema.regularTables]);
     SQL += this.foreignKeys(schema);
@@ -31,12 +31,14 @@ export default abstract class SQLPersisting {
    */
   public tableCreation(
     schema: Schema,
+    constraintPolicy: string,
     tables: Iterable<BasicTable> = schema.tables,
     keepSchema = false
   ): string {
     let Sql: string = '';
     for (const table of tables) {
-      Sql += this.createTableSql(schema, table, keepSchema) + '\n';
+      Sql +=
+        this.createTableSql(schema, table, constraintPolicy, keepSchema) + '\n';
     }
     return Sql;
   }
@@ -47,6 +49,7 @@ export default abstract class SQLPersisting {
   public createTableSql(
     schema: Schema,
     table: BasicTable,
+    constraintPolicy: string,
     keepSchema = false
   ): string {
     let columnStrings: string[] = [];
@@ -64,7 +67,7 @@ export default abstract class SQLPersisting {
 
     for (const column of columns) {
       let columnString: string = `${column.name} ${column.dataType} `;
-      if (!column.nullable) {
+      if (!column.nullableConstraint(constraintPolicy)) {
         columnString += 'NOT ';
       }
       columnString += 'NULL';

--- a/frontend/src/model/types/BasicColumn.ts
+++ b/frontend/src/model/types/BasicColumn.ts
@@ -6,6 +6,7 @@ export default interface BasicColumn {
   dataType: string;
   nullable: boolean;
   dataTypeString: string;
+  nullableConstraint(constraintPolicy: string): boolean;
 }
 
 export function surrogateKeyColumn(name: string): BasicColumn {
@@ -14,6 +15,7 @@ export function surrogateKeyColumn(name: string): BasicColumn {
     dataType: 'integer',
     nullable: false,
     dataTypeString: '(integer, not null)',
+    nullableConstraint: () => false,
   };
 }
 
@@ -27,5 +29,6 @@ export function newBasicColumn(
     dataType: dataType,
     nullable: nullable,
     dataTypeString: `(${dataType}, ${nullable ? 'null' : 'not null'})`,
+    nullableConstraint: () => nullable,
   };
 }

--- a/server/db/MsSqlUtils.ts
+++ b/server/db/MsSqlUtils.ts
@@ -18,6 +18,7 @@ import {
   KeyUnionability,
 } from "@/definitions/IUnionedKeys";
 import IRowCounts from "@/definitions/IRowCounts";
+import { IRequestBodyNotNull } from "@/definitions/IRequestBodyNotNull";
 
 // WARNING: make sure to always unprepare a PreparedStatement after everything's done
 // (or failed*), otherwise it will eternally use one of the connections from the pool and
@@ -144,6 +145,15 @@ export default class MsSqlUtils extends SqlUtils {
 
     if (result.recordset[0].count == 0) return KeyUnionability.allowed;
     return KeyUnionability.forbidden;
+  }
+
+  public override async testNotNullConstraint(
+    t: IRequestBodyNotNull
+  ): Promise<boolean> {
+    const _sql: string = this.testNotNullSql(t);
+    const result: sql.IResult<any> = await sql.query(_sql);
+
+    return result.recordset[0].notnull;
   }
 
   public override async getDatatypes(): Promise<string[]> {

--- a/server/db/MsSqlUtils.ts
+++ b/server/db/MsSqlUtils.ts
@@ -19,6 +19,7 @@ import {
 } from "@/definitions/IUnionedKeys";
 import IRowCounts from "@/definitions/IRowCounts";
 import { IRequestBodyNotNull } from "@/definitions/IRequestBodyNotNull";
+import IRequestBodyNewValue from "@/definitions/IRequestBodyNewValue";
 
 // WARNING: make sure to always unprepare a PreparedStatement after everything's done
 // (or failed*), otherwise it will eternally use one of the connections from the pool and
@@ -154,6 +155,15 @@ export default class MsSqlUtils extends SqlUtils {
     const result: sql.IResult<any> = await sql.query(_sql);
 
     return result.recordset[0].notnull;
+  }
+
+  public override async testNewValue(
+    t: IRequestBodyNewValue
+  ): Promise<boolean> {
+    const _sql: string = this.testNewValueSql(t);
+    const result: sql.IResult<any> = await sql.query(_sql);
+
+    return result.recordset[0].new;
   }
 
   public override async getDatatypes(): Promise<string[]> {

--- a/server/db/PostgresSqlUtils.ts
+++ b/server/db/PostgresSqlUtils.ts
@@ -19,6 +19,7 @@ import {
   KeyUnionability,
 } from "@/definitions/IUnionedKeys";
 import IRowCounts from "@/definitions/IRowCounts";
+import { IRequestBodyNotNull } from "@/definitions/IRequestBodyNotNull";
 export default class PostgresSqlUtils extends SqlUtils {
   protected config: PoolConfig;
   public constructor(
@@ -145,6 +146,16 @@ export default class PostgresSqlUtils extends SqlUtils {
 
     if (result.rows[0].count == 0) return KeyUnionability.allowed;
     return KeyUnionability.forbidden;
+  }
+
+  public override async testNotNullConstraint(
+    t: IRequestBodyNotNull
+  ): Promise<boolean> {
+    const _sql: string = this.testNotNullSql(t);
+
+    const result = await this.pool.query<{ notnull: boolean }>(_sql);
+
+    return result.rows[0].notnull;
   }
 
   /** The "null"-check is relevant for unionability-checks. */

--- a/server/db/PostgresSqlUtils.ts
+++ b/server/db/PostgresSqlUtils.ts
@@ -20,6 +20,7 @@ import {
 } from "@/definitions/IUnionedKeys";
 import IRowCounts from "@/definitions/IRowCounts";
 import { IRequestBodyNotNull } from "@/definitions/IRequestBodyNotNull";
+import IRequestBodyNewValue from "@/definitions/IRequestBodyNewValue";
 export default class PostgresSqlUtils extends SqlUtils {
   protected config: PoolConfig;
   public constructor(
@@ -156,6 +157,16 @@ export default class PostgresSqlUtils extends SqlUtils {
     const result = await this.pool.query<{ notnull: boolean }>(_sql);
 
     return result.rows[0].notnull;
+  }
+
+  public override async testNewValue(
+    t: IRequestBodyNewValue
+  ): Promise<boolean> {
+    const _sql: string = this.testNewValueSql(t);
+
+    const result = await this.pool.query<{ new: boolean }>(_sql);
+
+    return result.rows[0].new;
   }
 
   /** The "null"-check is relevant for unionability-checks. */

--- a/server/db/SqlUtils.ts
+++ b/server/db/SqlUtils.ts
@@ -14,6 +14,7 @@ import {
 } from "@/definitions/IUnionedKeys";
 import IRowCounts from "@/definitions/IRowCounts";
 import { IRequestBodyNotNull } from "@/definitions/IRequestBodyNotNull";
+import IRequestBodyNewValue from "@/definitions/IRequestBodyNewValue";
 
 export type SchemaQueryRow = {
   table_name: string;
@@ -107,6 +108,8 @@ export default abstract class SqlUtils {
     t: IRequestBodyNotNull
   ): Promise<boolean>;
 
+  public abstract testNewValue(t: IRequestBodyNewValue): Promise<boolean>;
+
   public abstract escape(str: string): string;
 
   public generateColumnString(columns: string[]): string {
@@ -155,6 +158,18 @@ export default abstract class SqlUtils {
         .map((name) => `${this.escape(name)} IS NULL`)
         .join("\n\t\tOR")}
     ) as notnull`;
+    return sql;
+  }
+
+  public testNewValueSql(nv: IRequestBodyNewValue): string {
+    const sql = `
+    SELECT NOT EXISTS (
+      SELECT ${this.escape(nv.columnName)}
+      FROM ${this.escape(nv.schemaName)}.${nv.tableName}
+      WHERE ${this.escape(nv.columnName)} = CAST('${nv.value}' AS ${
+      nv.dataType
+    })
+    ) as new;`;
     return sql;
   }
 

--- a/server/db/SqlUtils.ts
+++ b/server/db/SqlUtils.ts
@@ -153,10 +153,8 @@ export default abstract class SqlUtils {
     const sql = `
     SELECT NOT EXISTS(
       SELECT *
-      FROM (${nn.tableSql}) as X
-      WHERE ${nn.expectedKey
-        .map((name) => `${this.escape(name)} IS NULL`)
-        .join("\n\t\tOR")}
+      FROM ${this.escape(nn.schemaName)}.${nn.tableName}
+      WHERE ${this.escape(nn.columnName)} IS NULL
     ) as notnull`;
     return sql;
   }

--- a/server/definitions/IRequestBodyNewValue.ts
+++ b/server/definitions/IRequestBodyNewValue.ts
@@ -1,0 +1,7 @@
+export default interface IRequestBodyNewValue {
+  schemaName: string;
+  tableName: string;
+  columnName: string;
+  dataType: string;
+  value: string;
+}

--- a/server/definitions/IRequestBodyNotNull.ts
+++ b/server/definitions/IRequestBodyNotNull.ts
@@ -1,0 +1,4 @@
+export interface IRequestBodyNotNull {
+  tableSql: string;
+  expectedKey: Array<string>;
+}

--- a/server/definitions/IRequestBodyNotNull.ts
+++ b/server/definitions/IRequestBodyNotNull.ts
@@ -1,4 +1,5 @@
 export interface IRequestBodyNotNull {
-  tableSql: string;
-  expectedKey: Array<string>;
+  schemaName: string;
+  tableName: string;
+  columnName: string;
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -40,6 +40,7 @@ import getMaxValue from "./routes/maxValue";
 import getColumnSample from "./routes/columnSample";
 import getSchemaMatching from "./routes/schemaMatching";
 import checkNotNull from "./routes/checkNotNullConstraint";
+import checkNewValue from "./routes/checkNewValue";
 
 const app = express();
 
@@ -139,6 +140,8 @@ app.post(
   [body("tableSql").trim().custom(isValidSql())],
   checkNotNull
 );
+
+app.post("/newvalue", [], checkNewValue);
 
 app.post(
   "/violatingRows/fd",

--- a/server/index.ts
+++ b/server/index.ts
@@ -39,6 +39,7 @@ import getRedudanceGroupLength from "./routes/rankingRedudanceGroupLength";
 import getMaxValue from "./routes/maxValue";
 import getColumnSample from "./routes/columnSample";
 import getSchemaMatching from "./routes/schemaMatching";
+import checkNotNull from "./routes/checkNotNullConstraint";
 
 const app = express();
 
@@ -131,6 +132,12 @@ app.post(
   "/unionedkeys",
   [body("tableSql").trim().custom(isValidSql())],
   checkUnionedKeys
+);
+
+app.post(
+  "/notnull",
+  [body("tableSql").trim().custom(isValidSql())],
+  checkNotNull
 );
 
 app.post(

--- a/server/index.ts
+++ b/server/index.ts
@@ -135,11 +135,7 @@ app.post(
   checkUnionedKeys
 );
 
-app.post(
-  "/notnull",
-  [body("tableSql").trim().custom(isValidSql())],
-  checkNotNull
-);
+app.post("/notnull", [], checkNotNull);
 
 app.post("/newvalue", [], checkNewValue);
 

--- a/server/routes/checkNewValue.ts
+++ b/server/routes/checkNewValue.ts
@@ -1,0 +1,30 @@
+import { sqlUtils } from "@/db";
+import IRequestBodyNewValue from "@/definitions/IRequestBodyNewValue";
+import { isIRequestBodyNewValue } from "@/definitions/IRequestBodyNewValue.guard";
+import { Request, Response } from "express";
+import { validationResult } from "express-validator";
+
+export default async function checkNewValue(
+  req: Request,
+  res: Response
+): Promise<void> {
+  try {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(422).json({ errors: errors.mapped() });
+      return;
+    }
+
+    if (!isIRequestBodyNewValue(req.body)) {
+      res.status(422).json({ errors: "Invalid request body." });
+      return;
+    }
+
+    res
+      .status(200)
+      .json(await sqlUtils.testNewValue(req.body as IRequestBodyNewValue));
+  } catch (error) {
+    console.error(error);
+    res.status(502).json({ error: "Error while trying to test nullability." });
+  }
+}

--- a/server/routes/checkNotNullConstraint.ts
+++ b/server/routes/checkNotNullConstraint.ts
@@ -1,0 +1,32 @@
+import { sqlUtils } from "@/db";
+import { IRequestBodyNotNull } from "@/definitions/IRequestBodyNotNull";
+import { isIRequestBodyNotNull } from "@/definitions/IRequestBodyNotNull.guard";
+import { Request, Response } from "express";
+import { validationResult } from "express-validator";
+
+export default async function checkNotNull(
+  req: Request,
+  res: Response
+): Promise<void> {
+  try {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(422).json({ errors: errors.mapped() });
+      return;
+    }
+
+    if (!isIRequestBodyNotNull(req.body)) {
+      res.status(422).json({ errors: "Invalid request body." });
+      return;
+    }
+
+    res
+      .status(200)
+      .json(
+        await sqlUtils.testNotNullConstraint(req.body as IRequestBodyNotNull)
+      );
+  } catch (error) {
+    console.error(error);
+    res.status(502).json({ error: "Error while trying to test nullability." });
+  }
+}


### PR DESCRIPTION
Aktuell gibt es noch einen bug. Die persisting component kollidiert optisch mit dem angezeigten Tabellennamen, wenn eine Tabelle ausgewählt ist. Außerdem wäre ich sehr dankbar, wenn jemand das für mssql testen könnte.